### PR TITLE
CLI: Added support for exclude paths

### DIFF
--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -118,7 +118,7 @@ def _make_argument_parser():
     def _path_spec(arg):
         path = os.path.normpath(arg)
         if not os.path.isabs(path):
-            raise TypeError("Path '{}' is not absoulute or valid.".format(str(path)))
+            raise TypeError("Path '{}' is not absoulute or valid.".format(str(arg)))
 
         return path 
 
@@ -242,9 +242,17 @@ def main():
             self.disk = disk
             self.rsync_cp_backend = rsync_cp_backend
             self.container_name = container_name
-            self.excluded_paths = [
-                '/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*', '/mnt/*', '/media/*', '/lost+found/*'
-            ] + [ path + "/*" for path in excluded_paths ]
+
+            # Always excluded paths (FS related files etc.)
+            self.excluded_paths = ['/lost+found/*']
+
+            if not excluded_paths:
+                # Default excluded paths used only when --exclude-path wasn't used
+                self.excluded_paths = [
+                    '/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*', '/mnt/*', '/media/*'
+                ] + self.excluded_paths
+            else:
+                self.excluded_paths = [ path + "/*" for path in excluded_paths ] + self.excluded_paths
 
         def __get_machine_opt_by_context(self, machine_context):
             return (getattr(self, '{}_{}'.format(machine_context, opt)) for opt in ['addr', 'cfg', 'use_sshpass'])

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -115,6 +115,19 @@ def _make_argument_parser():
         type=_port_spec,
         help='define tcp ports which will be excluded from the mapped ports [[target_port]:source_port>]'
     )
+    def _path_spec(arg):
+        path = os.path.normpath(arg)
+        assert os.path.isabs(path)
+        return path 
+
+    migrate_cmd.add_argument(
+        '--exclude-path',
+        default=None,
+        dest="excluded_paths",
+        nargs='*',
+        type=_path_spec,
+        help='define paths which will be excluded from the source'
+    )
     #migrate_cmd.add_argument(
     #    '--udp-port',
     #    default=None,
@@ -218,7 +231,7 @@ def main():
         _SSH_CONTROL_PATH = '-o ControlPath="{}/%L-%r@%h:%p"'.format(_SSH_CTL_PATH)
 
         def __init__(self, target, target_ssh_cfg, disk, source=None, source_ssh_cfg=None,
-                     rsync_cp_backend=False, container_name=None):
+                     rsync_cp_backend=False, container_name=None, excluded_paths=None):
             self.source = source
             self.target = target
             self.source_use_sshpass, self.source_cfg = (None, None) if source_ssh_cfg is None else source_ssh_cfg
@@ -227,6 +240,11 @@ def main():
             self.disk = disk
             self.rsync_cp_backend = rsync_cp_backend
             self.container_name = container_name
+            self.excluded_paths = [
+                '/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*', '/mnt/*', '/media/*', '/lost+found/*'
+            ] + [ path + "/*" for path in excluded_paths ]
+
+            print(str(self.excluded_paths))
 
         def __get_machine_opt_by_context(self, machine_context):
             return (getattr(self, '{}_{}'.format(machine_context, opt)) for opt in ['addr', 'cfg', 'use_sshpass'])
@@ -643,7 +661,8 @@ def main():
             machine_src,
             _set_ssh_config(parsed.source_user, parsed.source_identity, parsed.source_ask_pass),
             parsed.use_rsync,
-            parsed.container_name
+            parsed.container_name,
+            parsed.excluded_paths
         )
 
         if not parsed.print_port_map:

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -117,7 +117,9 @@ def _make_argument_parser():
     )
     def _path_spec(arg):
         path = os.path.normpath(arg)
-        assert os.path.isabs(path)
+        if not os.path.isabs(path):
+            raise TypeError("Path '{}' is not absoulute or valid.".format(str(path)))
+
         return path 
 
     migrate_cmd.add_argument(
@@ -244,8 +246,6 @@ def main():
                 '/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*', '/mnt/*', '/media/*', '/lost+found/*'
             ] + [ path + "/*" for path in excluded_paths ]
 
-            print(str(self.excluded_paths))
-
         def __get_machine_opt_by_context(self, machine_context):
             return (getattr(self, '{}_{}'.format(machine_context, opt)) for opt in ['addr', 'cfg', 'use_sshpass'])
 
@@ -365,7 +365,7 @@ def main():
                         sys.exit(ret_code)
 
                     source_cmd = 'sudo rsync --rsync-path="sudo rsync" -aAX -r'
-                    for exd in ['/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*', '/mnt/*', '/media/*', '/lost+found/*']:
+                    for exd in self.excluded_paths:
                         source_cmd += ' --exclude=' + exd
                     source_cmd += ' -e "ssh {} {}" {}:/ {}'.format(
                         self._SSH_CONTROL_PATH, ' '.join(self.source_cfg), self.source_addr, rsync_dir

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -118,7 +118,7 @@ def _make_argument_parser():
     def _path_spec(arg):
         path = os.path.normpath(arg)
         if not os.path.isabs(path):
-            raise TypeError("Path '{}' is not absoulute or valid.".format(str(arg)))
+            raise ValueError("Path '{}' is not absoulute or valid.".format(str(arg)))
 
         return path 
 
@@ -373,8 +373,8 @@ def main():
                         sys.exit(ret_code)
 
                     source_cmd = 'sudo rsync --rsync-path="sudo rsync" -aAX -r'
-                    for exd in self.excluded_paths:
-                        source_cmd += ' --exclude=' + exd
+                    for excluded in self.excluded_paths:
+                        source_cmd += ' --exclude=' + excluded
                     source_cmd += ' -e "ssh {} {}" {}:/ {}'.format(
                         self._SSH_CONTROL_PATH, ' '.join(self.source_cfg), self.source_addr, rsync_dir
                     )

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -243,16 +243,14 @@ def main():
             self.rsync_cp_backend = rsync_cp_backend
             self.container_name = container_name
 
-            # Always excluded paths (FS related files etc.)
-            self.excluded_paths = ['/lost+found/*']
-
-            if not excluded_paths:
+            if excluded_paths is None:
                 # Default excluded paths used only when --exclude-path wasn't used
                 self.excluded_paths = [
-                    '/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*', '/mnt/*', '/media/*'
-                ] + self.excluded_paths
+                    '/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*', '/mnt/*', '/media/*', '/lost+found/*'
+                ]
             else:
-                self.excluded_paths = [ path + "/*" for path in excluded_paths ] + self.excluded_paths
+                self.excluded_paths = excluded_paths
+
 
         def __get_machine_opt_by_context(self, machine_context):
             return (getattr(self, '{}_{}'.format(machine_context, opt)) for opt in ['addr', 'cfg', 'use_sshpass'])


### PR DESCRIPTION
I've added --exclude-path option for migrate-machine command. I am not sure, whether we should keep the default list of excluded paths as it was before: 
  
  '/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*', '/mnt/*', '/media/*', '/lost+found/*'

Or rather go this way:

  '/dev/*', '/proc/*', '/sys/*', '/tmp/*', '/run/*',  '/lost+found/*'

Because there might be a situation that user will have some service data in /mnt or /media:

P.S. Virt-tar-out exclusion was not implemented since we are planning to drop it anyways.