### PR TITLE
add missing deps to leapp.spec 

### DIFF
--- a/leapp.spec
+++ b/leapp.spec
@@ -46,16 +46,19 @@ Requires:   libvirt-python
 Requires:   nmap
 Requires:   sshpass
 Requires:   python-enum34
+Requires:   docker 
 %if 0%{?el7}
 Requires:   python
 Requires:   python-psutil
 Requires:   python-nmap
 Requires:   python-paramiko
+Requires:   python-setuptools
 %else
 Requires:   python2
 Requires:   python2-nmap
 Requires:   python2-paramiko
 Requires:   python2-psutil
+Requires:   python2-setuptools
 %endif
 
 %description -n python2-%{name}

--- a/leapp.spec
+++ b/leapp.spec
@@ -46,7 +46,6 @@ Requires:   libvirt-python
 Requires:   nmap
 Requires:   sshpass
 Requires:   python-enum34
-Requires:   docker 
 Requires:   rsync
 %if 0%{?el7}
 Requires:   python
@@ -73,6 +72,7 @@ container host rather than providing their own.
 %package cockpit
 Summary:  Cockpit plugin for LeApp
 Requires: cockpit
+Requires: docker 
 Requires: %{name}-tool = %{version}-%{release}
 
 %description cockpit

--- a/leapp.spec
+++ b/leapp.spec
@@ -47,6 +47,7 @@ Requires:   nmap
 Requires:   sshpass
 Requires:   python-enum34
 Requires:   docker 
+Requires:   rsync
 %if 0%{?el7}
 Requires:   python
 Requires:   python-psutil


### PR DESCRIPTION
 right now leapp won't run on a fresh install, it misses docker during setup and python  libs