### PR TITLE
 create /var/lib/leapp/macrocontainers as part of leapp-cockpi…

### DIFF
--- a/leapp.spec
+++ b/leapp.spec
@@ -126,6 +126,7 @@ popd
 %files cockpit
 %doc README.md AUTHORS COPYING
 %dir %attr (755,root,root) %{_datadir}/cockpit/%{name}
+%dir %attr (755,root,root) /var/lib/leapp/macrocontainers
 %attr(644, root, root) %{_datadir}/cockpit/%{name}/*
 
 


### PR DESCRIPTION
right now when the app is freshly installed the user would receive an error in cockpit. Following the cockpit idea this should be seamless for the user. 
http://imgur.com/nFZjDHY
http://imgur.com/Hku77wh


