### PR TITLE
Enable systemd based source machine migration

### DIFF
--- a/ansible_roles/docker/tasks/main.yml
+++ b/ansible_roles/docker/tasks/main.yml
@@ -8,3 +8,9 @@
     name: docker 
     state: started 
     enabled: yes
+
+- name: "SElinux: allow container to manage cgroups"
+  seboolean:
+    name: container_manage_cgroup
+    persistent: yes
+    state: yes

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -18,6 +18,15 @@ Scenario: Migrate between remote hosts using rsync
     Then the HTTP 403 response on port 80 should match within 120 seconds
      And attempting another migration should fail within 10 seconds
 
+Scenario: Migrate between remote hosts using rsync - systemd
+   Given the local virtual machines:
+         | name       | definition          | ensure_fresh |
+         | app-source | centos7-guest-httpd | no           |
+         | target     | centos7-target      | no           |
+    When app-source is migrated to target as a macrocontainer and rsync is used for fs migration
+    Then the HTTP 403 response on port 80 should match within 120 seconds
+     And attempting another migration should fail within 10 seconds
+
 Scenario: Forced migration overwriting an existing container
    Given the local virtual machines:
          | name       | definition          | ensure_fresh |

--- a/integration-tests/vmdefs/centos7-guest-httpd/Vagrantfile
+++ b/integration-tests/vmdefs/centos7-guest-httpd/Vagrantfile
@@ -1,0 +1,22 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box = "centos/7"
+    config.vm.define "leapp-tests"
+    config.vm.hostname = "leapp-tests-centos7-guest-httpd"
+
+    config.vm.network :private_network, ip: "10.0.0.100"
+
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.memory = 512 
+        libvirt.cpus = 1
+    end
+
+    config.vm.provision "ansible" do |ansible|
+        ansible.playbook = "ansible/playbook.yml"
+        ansible.sudo = true
+    end
+
+    config.vm.provision :shell, inline: "echo Good job, now enjoy your new vbox: http://10.0.0.10"
+
+end

--- a/integration-tests/vmdefs/centos7-guest-httpd/ansible.cfg
+++ b/integration-tests/vmdefs/centos7-guest-httpd/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ../../../ansible_roles

--- a/integration-tests/vmdefs/centos7-guest-httpd/ansible/playbook.yml
+++ b/integration-tests/vmdefs/centos7-guest-httpd/ansible/playbook.yml
@@ -1,0 +1,6 @@
+---
+ - hosts: all
+   roles:
+    - role: init
+      key_path: ../../../config/leappto_testing_key.pub
+    - httpd

--- a/src/README.rst
+++ b/src/README.rst
@@ -23,3 +23,9 @@ Installation
 Installation is currently only supported as part of
 the LeApp Cockpit plugin demo or the LeApp integration
 tests.
+
+SELinux
+-------
+Please enable *container_manage_cgroup* boolean in order to manage cgroups within container.
+
+  semanage boolean -m -1 container_manage_cgroup

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -756,8 +756,10 @@ def main():
                 
             ]
 
-            result = mc.start_container('centos/systemd',
-                                        #'/usr/lib/systemd/systemd --system',
+            # centos/systemd doesn't have any other tag than latest
+            # but it is derived from centos:7 image
+            result = mc.start_container('centos/systemd:latest',
+                                        # This is not relict from CentOS6, it will execute systemd properly 
                                         '/sbin/init',
                                         tcp_mapping,
                                         " ".join(opts))

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -759,7 +759,7 @@ def main():
             # centos/systemd doesn't have any other tag than latest
             # but it is derived from centos:7 image
             result = mc.start_container('centos/systemd:latest',
-                                        # This is not relict from CentOS6, it will execute systemd properly 
+                                        # This is not a relict from CentOS6, it will execute systemd properly
                                         '/sbin/init',
                                         tcp_mapping,
                                         " ".join(opts))


### PR DESCRIPTION
Image is now based on centos/systemd in order to save some work with removing *.wanted folders content. 
To be able to run it, the container_manage_cgroup selinux boolean has to be enabled (P.S. even for upstart based distros, if we want to access cgroups)
"--cap-add", "SYS_ADMIN" parameter also added since this will be required on docker 1.13 (tested), but it works without it on current fedora docker 1.12 
