### PR TITLE
Set default target for destroy-container and check-target

### DIFF
--- a/cockpit/leapp.html
+++ b/cockpit/leapp.html
@@ -715,7 +715,7 @@
         }
 
         function load_target_container_names() {
-            var ctx = new_leapp_call(["check-target", "127.0.0.1"]);
+            var ctx = new_leapp_call(["check-target", "-t", "127.0.0.1"]);
             ctx.log("Loading used applications names from the target...");
             ctx.done(set_app_list);
             ctx.run();

--- a/docs/source/leapp-tool.rst
+++ b/docs/source/leapp-tool.rst
@@ -53,23 +53,25 @@ migrate-machine
 destroy-containers
 ^^^^^^^^^^^^^^^^^^
     **usage:**
-        leapp-tool destroy-containers [-h] [--identity IDENTITY] [--ask-pass]
-                                      [--user USER]
-                                      target
+        leapp-tool destroy-container [-h] [-t TARGET] [--identity IDENTITY]
+                                    [--ask-pass] [--user USER]
+                                    container
+                                      
     
     positional arguments:
         +-------------+---------------------------+
-        | target      | target VM name            |
+        | container   | container name            |
         +-------------+---------------------------+
 
     
     optional arguments:
-        ========================  =============================== 
-        -h, --help                Show this help message and exit
-        --identity IDENTITY       Path to private SSH key
-        --ask-pass, -k            Ask for SSH password
-        --user USER, -u USER      Connect as this user
-        ========================  =============================== 
+        ==========================  =============================== 
+        -h, --help                  Show this help message and exit
+        -t TARGET, --target TARGET  target docker machine 
+        --identity IDENTITY         Path to private SSH key
+        --ask-pass, -k              Ask for SSH password
+        --user USER, -u USER        Connect as this user
+        ==========================  =============================== 
 
 
 port-inspect

--- a/docs/source/leapp-tool.rst
+++ b/docs/source/leapp-tool.rst
@@ -38,7 +38,7 @@ migrate-machine
     optional arguments:
         ==================================================  =======================================================
         -h, --help                                          Show this help message and exit
-        -t TARGET, --target TARGET                          target VM name
+        -t TARGET, --target TARGET                          Target container host 
         --tcp-port [FORWARDED_PORTS [FORWARDED_PORTS ...]]  Target ports to forward to macrocontainer (temporary!)
         --source-identity IDENTITY                          Path to private SSH key for the source machine
         --source-ask-pass                                   Ask for SSH password for the source machine
@@ -67,7 +67,7 @@ destroy-containers
     optional arguments:
         ==========================  =============================== 
         -h, --help                  Show this help message and exit
-        -t TARGET, --target TARGET  target docker machine 
+        -t TARGET, --target TARGET  Target container host 
         --identity IDENTITY         Path to private SSH key
         --ask-pass, -k              Ask for SSH password
         --user USER, -u USER        Connect as this user

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -234,7 +234,7 @@ class ClientHelper(object):
     def check_target(self, target_vm, time_limit=10):
         """Check viability of target VM and report currently unavailable names"""
         command_output = self.check_response_time(
-            ["check-target", self._vm_helper.get_hostname(target_vm)],
+            ["check-target", "-t", self._vm_helper.get_hostname(target_vm)],
             time_limit,
             use_default_identity=True
         )

--- a/integration-tests/features/steps/destroy_containers.py
+++ b/integration-tests/features/steps/destroy_containers.py
@@ -10,7 +10,7 @@ def check_destroy_container(context, container, target, time_limit):
     if not claimed_names:
         raise RuntimeError("Claim names in test scenario setup to use this step")
     context.cli_helper.check_response_time(
-        ["destroy-container", context.vm_helper.get_hostname(target), container],
+        ["destroy-container", "-t", context.vm_helper.get_hostname(target), container],
         time_limit,
         use_default_identity=True
     )

--- a/integration-tests/features/steps/remote_authentication.py
+++ b/integration-tests/features/steps/remote_authentication.py
@@ -11,7 +11,7 @@ def skip_unless_running_as_root(context):
 
 def _make_auth_test_command(context, target):
     """Create a leapp-to command to test remote authentication"""
-    return ["check-target", context.vm_helper.get_hostname(target)]
+    return ["check-target", "-t", context.vm_helper.get_hostname(target)]
 
 @given("ssh-agent is running")
 def ensure_ssh_agent_is_running(context):

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -169,10 +169,10 @@ def _make_argument_parser():
     _add_identity_options(migrate_cmd, context='source')
     _add_identity_options(migrate_cmd, context='target')
 
-    check_target_cmd.add_argument('target', help='target VM name')
+    check_target_cmd.add_argument('-t', '--target', default='localhost', help='Target running docker')
     _add_identity_options(check_target_cmd)
 
-    destroy_cmd.add_argument('target', help='target VM name')
+    destroy_cmd.add_argument('-t', '--target', default='localhost', help='Target running docker')
     destroy_cmd.add_argument('container', help='container to destroy (if it exists)')
     _add_identity_options(destroy_cmd)
 

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -169,10 +169,10 @@ def _make_argument_parser():
     _add_identity_options(migrate_cmd, context='source')
     _add_identity_options(migrate_cmd, context='target')
 
-    check_target_cmd.add_argument('-t', '--target', default='localhost', help='Target running docker')
+    check_target_cmd.add_argument('-t', '--target', default='localhost', help='Target container host')
     _add_identity_options(check_target_cmd)
 
-    destroy_cmd.add_argument('-t', '--target', default='localhost', help='Target running docker')
+    destroy_cmd.add_argument('-t', '--target', default='localhost', help='Target container host')
     destroy_cmd.add_argument('container', help='container to destroy (if it exists)')
     _add_identity_options(destroy_cmd)
 


### PR DESCRIPTION
Set default target for:
  destroy-container
  check-target

And unified it with migrate-machine, so the target can be changed using -t option.