### PR TITLE
Proper shutdown procedure for Upstart macrocontainers

### DIFF
--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -795,11 +795,12 @@ def main():
             fullfiles = ['{d}/{f}'.format(d=container_dir, f=f) for f in addfiles]
             pre_command = 'touch ' + ' '.join(fullfiles) + ' && '
             vol_commands = ['-v {d}/{f}:/{f}:ro,Z'.format(d=container_dir, f=f) for f in addfiles]
-            vol_command = ' '.join(vol_commands)
+            shutdown_command = ['--stop-signal', 'SIGINT']
+            opts = vol_commands + shutdown_command
             result = mc.start_container('centos:6',
                                         '/sbin/init',
                                         tcp_mapping,
-                                        vol_command,
+                                        " ".join(opts),
                                         pre_command)
         print_migrate_info('! done')
         sys.exit(result)


### PR DESCRIPTION
Currently `docker stop` sends SIGTERM and then simply kills everything, as Upstart does not react to SIGTERM. This caused fsck to be run (before that was fixed in other PRs) and probably is not ideal for various other reasons (e.g. databases might prefer to be shutdown properly instead of being just killed).

Fix this by letting Docker send SIGINT to Upstart to let it shutdown the services properly. Upstart interprets SIGINT as Ctrl-Alt-Del and runs the shutdown scripts.

To verify that it works properly for the demo case: run `docker stop` and check that  /var/lib/leapp/macrocontainers/container_centos6-app-vm/var/log/mysql55-mysqld.log contains
`[Note] /opt/rh/mysql55/root/usr/libexec/mysqld: Shutdown complete`
and /var/lib/leapp/macrocontainers/container_centos6-app-vm/var/log/httpd/error_log contains
`caught SIGTERM, shutting down`