### PR TITLE
MOD: Splinter version fix to <0.7.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,9 @@ pylint = "*"
 requests = "*"
 attrs = "*"
 PyHamcrest = "*"
-splinter = "*"
+# Since we restrict the version of selenium and this is its dependency, we have
+# to restrict it as well
+splinter = "< 0.7.6"
 # We restrict ourselves to older versions of Selenium for the Cockpit plugin
 # testing as:
 #


### PR DESCRIPTION
I discovered this issue while I was testing the docker images. Basically what is going on here is that we require selenium version < 3.0, but we do not limit the dependencies of selenium. The result was that the dependency tree could not be solved. 