### PR TITLE
centos-ci/bootstrap.sh: fix epel release url

### DIFF
--- a/centos-ci/bootstrap.sh
+++ b/centos-ci/bootstrap.sh
@@ -20,7 +20,7 @@ if [[ $(id -u) != 0 ]]; then
    echo "$0 needs to be run as root" ; exit 1
 fi
 
-yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install -y python2-pip gcc redhat-rpm-config openssl-devel python-devel wget git ansible
 
 # Interim EPEL-based approach to enable testing of --ask-pass option


### PR DESCRIPTION
Hardcoding epel version will work only temporarily. Idea from:
https://github.com/geerlingguy/ansible-role-repo-epel/blob/master/defaults/main.yml

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>