### PR TITLE
Added makefile with dummy targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+ROOT_PATH=$(PREFIX)/usr/bin
+
+clean:
+	true
+
+build:
+	true
+
+install-deps:
+	true
+
+install:
+	true
+
+test:
+	true	
+
+.PHONY: clean build install-deps install test


### PR DESCRIPTION
Added makefile which contains so far just dummy targets. This is needed in order to unify build process of every single core repository.