### PR TITLE
Add support for sphinx-autobuild

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,11 +1,12 @@
 # Minimal makefile for Sphinx documentation
 #
 ## default build operation:
-all: clean html 
+all: clean html
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXAUTOBUILD = sphinx-autobuild
 SPHINXPROJ    = Leapp
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -13,6 +14,8 @@ BUILDDIR      = build
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+livehtml:
+	@$(SPHINXAUTOBUILD) "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(0)
 
 .PHONY: help Makefile
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ Welcome to Leapp's documentation!
 
     terminology
     tutorials
+    debugging
     best-practises
     contributing
     python-coding-guidelines

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,4 +3,5 @@
 CommonMark==0.7.5
 sphinx>=1.5,<1.6
 sphinx_rtd_theme
+sphinx-autobuild
 git+https://github.com/leapp-to/recommonmark.git@master


### PR DESCRIPTION
[Sphinx-autobuild](https://github.com/GaretJax/sphinx-autobuild) - Watch a Sphinx directory and rebuild the documentation when a change is detected. Also includes a livereload enabled web server.

Usage to run the server on localhost:
`$ make livehtml`