### PR TITLE
Add manpages for leapp and snactor executables

### DIFF
--- a/leapp.spec
+++ b/leapp.spec
@@ -146,7 +146,10 @@ install -m 0755 -d %{buildroot}%{_sharedstatedir}/leapp
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/repos.d
 install -m 0600 -d %{buildroot}%{_sysconfdir}/leapp/answers
+install -m 0755 -d %{buildroot}%{_mandir}/man1
 install -m 0644 etc/leapp/*.conf %{buildroot}%{_sysconfdir}/leapp
+install -m 0644 -p man/leapp.1 %{buildroot}%{_mandir}/man1/
+install -m 0644 -p man/snactor.1 %{buildroot}%{_mandir}/man1/
 
 %if %{with python2}
 %py2_install
@@ -163,6 +166,7 @@ install -m 0644 etc/leapp/*.conf %{buildroot}%{_sysconfdir}/leapp
 %defattr(-,root,root,-)
 %doc README.md
 %license COPYING
+%{_mandir}/man1/leapp.1*
 %config(noreplace) %{_sysconfdir}/leapp/leapp.conf
 %config(noreplace) %{_sysconfdir}/leapp/logger.conf
 %dir %{_sysconfdir}/leapp
@@ -178,6 +182,7 @@ install -m 0644 etc/leapp/*.conf %{buildroot}%{_sysconfdir}/leapp
 # snactor files
 ##################################################
 %files -n snactor
+%{_mandir}/man1/snactor.1*
 %{_bindir}/snactor
 
 

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,0 +1,34 @@
+.TH LEAPP "1" "30/09/2018" "leapp 0.3" "User Commands"
+.SH NAME
+leapp - command-line interface to for App & OS Modernization Framework Leapp
+.SH SYNOPSIS
+leapp [-h|--help] [--version] [--debug] <command>
+.SH DESCRIPTION
+The leapp tool is an end-user application designed to run specific workflows.
+.SH OPTIONS
+-h, --help
+    show this help message and exit
+
+--version
+    show program's version number and exit
+
+--debug
+    Enables debug logging
+.SH "LEAPP COMMANDS"
+upgrade
+    Upgrades the current system to the next available major version.
+.SH "ENVIRONMENT VARIABLES"
+LEAPP_CONFIG
+.RS 4
+This environment variable allows to override the default location of leapp.conf. If not specified, .leapp/leapp.conf is used when the command is executed inside a leapp repository, otherwise the default /etc/leapp/leapp.conf is used.
+.RE
+
+LEAPP_LOGGER_CONFIG
+.RS 4
+This environment variable allows to override the default location of logger.conf. If not specified, the default /etc/leapp/logger.conf is used.
+.RE
+.SH "REPORTING BUGS"
+Report bugs to the issue tracker <https://github.com/leapp-to/leapp/issues> or to the mailing list <leapp-devel@redhat.com>.
+.SH "SEE ALSO"
+snactor(1)
+More info available at <https://leapp.readthedocs.io/>.

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,0 +1,68 @@
+.TH SNACTOR "1" "30/09/2018" "snactor 0.3" "User Commands"
+.SH NAME
+snactor - development and repository management tool for App & OS Modernization Framework Leapp
+.SH SYNOPSIS
+snactor [-h|--help] [--version] [--logger-config <LOGGER_CONFIG>]
+        [--config <CONFIG>] [--debug] <command>
+.SH DESCRIPTION
+Snactor is designed to get quickly started with leapp actor development and allows you to run custom workflows.
+.SH OPTIONS
+-h, --help
+    show this help message and exit
+
+--version
+    show program's version number and exit
+
+--logger-config <LOGGER_CONFIG>
+    Allows to override the logger.conf location
+
+--config <CONFIG>
+    Allows to override the leapp.conf location
+
+--debug
+    Enables debug logging
+.SH "SNACTOR COMMANDS"
+discover
+    Discovers all available entities in the current repository
+
+new-actor
+    Creates a new actor
+
+new-model
+    Creates a new model
+
+new-project
+    [DEPRECATED] Creates a new repository
+
+new-tag
+    Create a new tag
+
+new-topic
+    Creates a new topic
+
+run
+    Execute the given actor
+
+messages
+    Messaging related commands
+
+workflow
+    Workflow related commands
+
+repo
+    Repository related commands
+.SH "ENVIRONMENT VARIABLES"
+LEAPP_CONFIG
+.RS 4
+This environment variable allows to override the default location of leapp.conf. If not specified, .leapp/leapp.conf is used when the command is executed inside a leapp repository, otherwise the default /etc/leapp/leapp.conf is used.
+.RE
+
+LEAPP_LOGGER_CONFIG
+.RS 4
+This environment variable allows to override the default location of logger.conf. If not specified, the default /etc/leapp/logger.conf is used.
+.RE
+.SH "REPORTING BUGS"
+Report bugs to the issue tracker <https://github.com/leapp-to/leapp/issues> or to the mailing list <leapp-devel@redhat.com>.
+.SH "SEE ALSO"
+leapp(1)
+More info available at <https://leapp.readthedocs.io/>.

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -31,9 +31,6 @@ new-actor
 new-model
     Creates a new model
 
-new-project
-    [DEPRECATED] Creates a new repository
-
 new-tag
     Create a new tag
 


### PR DESCRIPTION
Manpages are generated by help2man tool by a Makefile target `manpages`.
What is missing are inculde files (`man/{leapp,snactor}.h2m`) to be used by help2man tools to make the output look less stubble.
