### PR TITLE
Handle "snactor" failing when actor name not found

### DIFF
--- a/leapp/snactor/commands/run.py
+++ b/leapp/snactor/commands/run.py
@@ -1,7 +1,7 @@
 import json
 import sys
 
-from leapp.exceptions import LeappError
+from leapp.exceptions import LeappError, CommandError
 from leapp.utils.clicmd import command, command_opt, command_arg
 from leapp.utils.repository import requires_repository, find_repository_basedir
 from leapp.logger import configure_logger
@@ -36,6 +36,8 @@ def cli(args):
         sys.exit(1)
     actor_logger = log.getChild('actors')
     actor = repository.lookup_actor(args.actor_name)
+    if not actor:
+        raise CommandError('Actor "{}" not found!'.format(args.actor_name))
     messaging = InProcessMessaging(stored=args.save_output)
     messaging.load(actor.consumes)
 


### PR DESCRIPTION
When issuing "snactor run Scaner" (typo here) command, snactor
fails with:

`AttributeError: 'NoneType' object has no attribute 'consumes'
`

This commit handles the situation when actor is not found or when
there is a typo.