### PR TITLE
Doc - remove "filters" import statement as it does not exist

### DIFF
--- a/docs/source/working-with-workflows.md
+++ b/docs/source/working-with-workflows.md
@@ -15,7 +15,6 @@ This procedure creates the Example workflow boilerplate:
 from leapp.workflows import Workflow
 from leapp.workflows.phases import Phase
 from leapp.workflows.flags import Flags
-from leapp.workflows.filters import Filter
 from leapp.workflows.tagfilters import TagFilter
 from leapp.workflows.policies import Policies
 from leapp.tags import ExampleWorkflowTag
@@ -91,7 +90,6 @@ The whole example workflow:
 from leapp.workflows import Workflow
 from leapp.workflows.phases import Phase
 from leapp.workflows.flags import Flags
-from leapp.workflows.filters import Filter
 from leapp.workflows.tagfilters import TagFilter
 from leapp.workflows.policies import Policies
 from leapp.tags import ExampleWorkflowTag, ScanTag, ReportsTag


### PR DESCRIPTION
Issuing "snactor workflow run Example" from working-with-workflows.md doc fails with:

```(venv) [mreznik@localhost tutorial-linked]$ snactor workflow run Example
2018-10-04 17:41:37.889 INFO     PID: 26918 leapp: Logging has been initialized
2018-10-04 17:41:37.918 INFO     PID: 26918 leapp.repository.tutorial-linked: A new repository 'tutorial-linked' is initialized at /home/mreznik/work/upstream/leapp/tutorial-linked
2018-10-04 17:41:37.939 INFO     PID: 26918 leapp.repository.tutorial: A new repository 'tutorial' is initialized at /home/mreznik/work/upstream/leapp/tutorial
Traceback (most recent call last):
  File "/home/mreznik/work/upstream/leapp/venv/bin/snactor", line 11, in <module>
    sys.exit(main())
  File "/home/mreznik/work/upstream/leapp/venv/lib/python2.7/site-packages/leapp/snactor/__init__.py", line 68, in main
    cli.command.execute(version='snactor version {}'.format(VERSION))
  File "/home/mreznik/work/upstream/leapp/venv/lib/python2.7/site-packages/leapp/utils/clicmd.py", line 81, in execute
    args.func(args)
  File "/home/mreznik/work/upstream/leapp/venv/lib/python2.7/site-packages/leapp/utils/clicmd.py", line 103, in called
    self.target(args)
  File "/home/mreznik/work/upstream/leapp/venv/lib/python2.7/site-packages/leapp/utils/repository.py", line 20, in checker
    return f(*args, **kwargs)
  File "/home/mreznik/work/upstream/leapp/venv/lib/python2.7/site-packages/leapp/snactor/commands/workflow/run.py", line 38, in cli
    repository.load()
  File "/home/mreznik/work/upstream/leapp/venv/lib/python2.7/site-packages/leapp/repository/manager.py", line 97, in load
    repo.load(resolve=False, stage=_LoadStage.WORKFLOWS)
  File "/home/mreznik/work/upstream/leapp/venv/lib/python2.7/site-packages/leapp/repository/__init__.py", line 155, in load
    self._load_modules(self.workflows)
  File "/home/mreznik/work/upstream/leapp/venv/lib/python2.7/site-packages/leapp/repository/__init__.py", line 178, in _load_modules
    importer.find_module(name).load_module(name)
  File "/usr/lib64/python2.7/pkgutil.py", line 243, in load_module
    mod = imp.load_module(fullname, self.file, self.filename, self.etc)
  File "/home/mreznik/work/upstream/leapp/tutorial-linked/workflows/example.py", line 4, in <module>
    from leapp.workflows.filters import Filter
ImportError: No module named filters
```

The import statement was probably introduced by mistake.