### PR TITLE
Fix inheritance of Models

### DIFF
--- a/leapp/models/__init__.py
+++ b/leapp/models/__init__.py
@@ -57,7 +57,8 @@ class ModelMeta(type):
                 raise ModelDefinitionError('Missing topic in Model {}'.format(name))
             topic.messages = tuple(set(topic.messages + (klass,)))
 
-        kls_attrs = {name: value for name, value in attrs.items() if isinstance(value, fields.Field)}
+        kls_attrs = (getattr(klass, 'fields', None) or {}).copy()
+        kls_attrs.update({name: value for name, value in attrs.items() if isinstance(value, fields.Field)})
         klass.fields = kls_attrs.copy()
 
         setattr(sys.modules[mcs.__module__], name, klass)

--- a/tests/scripts/test_models.py
+++ b/tests/scripts/test_models.py
@@ -13,6 +13,18 @@ class UnitTestModel(leapp.models.Model):
     integer = leapp.models.fields.Integer()
 
 
+class InheritedUnitTestModel(UnitTestModel):
+    pass
+
+
+class ExtendedInheritedUnitTestModel(InheritedUnitTestModel):
+    boolean = leapp.models.fields.Boolean(default=False, required=True)
+
+
+class ExtendedOverriddenInheritedUnitTestModel(ExtendedInheritedUnitTestModel):
+    integer = leapp.models.fields.Number()
+
+
 def test_model_definition_error():
     with pytest.raises(ModelDefinitionError):
         type('FailingModelDefinition', (leapp.models.Model,), {})
@@ -30,3 +42,35 @@ def test_init_from_tuple():
     integer_value = 2
     model = init_from_tuple(UnitTestModel, ('strings', 'integer'), (strings_value, integer_value))
     assert model.strings == ['first', 'second', 'third'] and model.integer == integer_value
+
+
+def test_inheritance():
+    strings_value = ['first', 'second', 'third']
+    integer_value = 2.4
+    boolean_value = True
+    a = ExtendedOverriddenInheritedUnitTestModel(strings=strings_value,
+                                                 integer=integer_value,
+                                                 boolean=boolean_value)
+    assert a.boolean == boolean_value
+    assert a.strings == strings_value
+    assert a.integer == integer_value
+    assert len(ExtendedOverriddenInheritedUnitTestModel.fields) == 3
+
+    with pytest.raises(leapp.models.fields.ModelViolationError):
+        # Ensure that passing a wrong value type will raise an exception if the field was defined in a base class
+        # and overridden by a derived class. In this case  ExtendedOverriddenInheritedUnitTestModel overrides the field
+        # integer to be a number, passing a number to the non overridden base class will still keep raising an exception
+        ExtendedInheritedUnitTestModel(strings=strings_value, integer=integer_value, boolean=boolean_value)
+
+    assert isinstance(ExtendedOverriddenInheritedUnitTestModel.fields['boolean'], leapp.models.fields.Boolean)
+    assert isinstance(ExtendedOverriddenInheritedUnitTestModel.fields['integer'], leapp.models.fields.Number)
+    assert isinstance(ExtendedOverriddenInheritedUnitTestModel.fields['strings'], leapp.models.fields.List)
+
+    assert isinstance(ExtendedInheritedUnitTestModel.fields['boolean'], leapp.models.fields.Boolean)
+    assert isinstance(ExtendedInheritedUnitTestModel.fields['integer'], leapp.models.fields.Integer)
+    assert isinstance(ExtendedInheritedUnitTestModel.fields['strings'], leapp.models.fields.List)
+
+    assert len(InheritedUnitTestModel.fields) == 2
+    assert isinstance(InheritedUnitTestModel.fields['integer'], leapp.models.fields.Integer)
+    assert isinstance(InheritedUnitTestModel.fields['strings'], leapp.models.fields.List)
+    assert InheritedUnitTestModel.fields is not UnitTestModel.fields


### PR DESCRIPTION
Previously when inheriting from a Model, fields from the base class weren't taken into account.
This PR fixes this mistake by copying the fields from the base class