### PR TITLE
WIP: Remove allow_null and missing from models fields

### DIFF
--- a/leapp/models/__init__.py
+++ b/leapp/models/__init__.py
@@ -133,7 +133,7 @@ class ErrorModel(Model):
 
     message = fields.String(required=True)
     severity = fields.StringEnum(required=True, choices=ErrorSeverity.ALLOWED_VALUES, default=ErrorSeverity.ERROR)
-    details = fields.String(required=True, allow_null=True, default=None)
+    details = fields.String(required=True, default=None)
     actor = fields.String(required=True)
     time = fields.DateTime(required=True)
 

--- a/tests/scripts/test_models.py
+++ b/tests/scripts/test_models.py
@@ -9,7 +9,7 @@ from test_topics import UnitTestTopic
 
 class UnitTestModel(leapp.models.Model):
     topic = UnitTestTopic
-    strings = leapp.models.fields.List(leapp.models.fields.String(), allow_null=True)
+    strings = leapp.models.fields.List(leapp.models.fields.String(), required=False)
     integer = leapp.models.fields.Integer()
 
 


### PR DESCRIPTION
We do not see use-case to be able to distinguish whether value of model's attribute is None or was not be set at all. The original solution was confusing and there was not any actor writer that would expect such non-python logic. To make everything clear, remove the "missing" function and allow_null and simplify the logic just to use the "required" value for fields.

So the current logic:
  - If required is set to True for a field, expect that field cannot
    contains the None value.
  - If required is set to False (default) for a field, the field can
    contains the None value.