### PR TITLE
Set & use the LEAPP_DEBUG env properly

### DIFF
--- a/docs/source/debugging.md
+++ b/docs/source/debugging.md
@@ -10,7 +10,7 @@ file, and pass the arguments on the command line.
 The PyCharm debugger also follows the child processes that are created by the
 snactor tool to execute the actor in a sandboxed environment.
 
-The snactor tool has also the --debug parameter and checks for the environment variable
-`LEAPP_DEBUG` if it is set to '1'.
-In that case, it enables the debug logging, so that any actor that logs to self.log.debug
-gets its output printed on the commandline.
+The snactor tool checks for the `LEAPP_DEBUG` environment variable and has also
+the --debug parameter which sets the environment variable to '1' when it is
+used. In that case, it enables the debug logging, so that any actor that logs
+to self.log.debug gets its output printed on the commandline.

--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -9,7 +9,7 @@ from leapp import VERSION
 @command('')
 @command_opt('debug', is_flag=True, help='Enable debug logging', inherit=True)
 def cli(args):
-    os.environ['LEAPP_DEBUG'] = '1' if args.debug else '0'
+    os.environ['LEAPP_DEBUG'] = '1' if args.debug else os.environ.get('LEAPP_DEBUG', '0')
 
 
 def main():

--- a/leapp/logger/__init__.py
+++ b/leapp/logger/__init__.py
@@ -60,7 +60,7 @@ def configure_logger():
             log_format = '%(asctime)s.%(msecs)-3d %(levelname)-8s PID: %(process)d %(name)s: %(message)s'
             log_date_format = '%Y-%m-%d %H:%M:%S'
             logging.basicConfig(
-                level=logging.DEBUG if os.getenv('LEAPP_DEBUG', '1') == '1' else logging.INFO,
+                level=logging.DEBUG if os.getenv('LEAPP_DEBUG', '0') == '1' else logging.INFO,
                 format=log_format,
                 datefmt=log_date_format,
                 stream=sys.stderr,

--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -59,7 +59,7 @@ def cli(args):
         config_file_path = '/etc/leapp/leapp.conf'
 
     os.environ['LEAPP_CONFIG'] = config_file_path
-    os.environ['LEAPP_DEBUG'] = '1' if args.debug else '0'
+    os.environ['LEAPP_DEBUG'] = '1' if args.debug else os.environ.get('LEAPP_DEBUG', '0')
 
 
 def main():


### PR DESCRIPTION
tl;dr;
- Do not override the LEAPP_DEBUG value when the --debug option is
  not used and LEAPP_DEBUG is already set.
- Set a logging level to DEBUG only when LEAPP_DEBUG == 1, otherwise
  use the INFO level.

Previously, the LEAPP tool ignored LEAPP_DEBUG set from the
commandline completely. So the value has been set only based on
use of the --debug option. Additionaly, the logging level has been
set to DEBUG in case the LEAPP_DEBUG has not been set.