### PR TITLE
actordefinition: Make stdin opening more robust

### DIFF
--- a/leapp/repository/actor_definition.py
+++ b/leapp/repository/actor_definition.py
@@ -49,7 +49,10 @@ class ActorCallContext(object):
     @staticmethod
     def _do_run(stdin, logger, messaging, definition, args, kwargs):
         if stdin is not None:
-            sys.stdin = os.fdopen(stdin)
+            try:
+                sys.stdin = os.fdopen(stdin)
+            except OSError:
+                pass
         definition.load()
         with definition.injected_context():
             target_actor = [actor for actor in get_actors() if actor.name == definition.name][0]


### PR DESCRIPTION
When executing leapp in a debugger it can happen that stdin can not
be opened with fdopen, in this case an OSError can occur. This patch
handles that scenario, but will imply that stdin might not be working
as expected in some cases. We won't be able to handle those cases but
this only happens within a debugger at this point. Therefore this
patch is good enough for now.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>