### PR TITLE
upgrade: Auto reboot functionality

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -43,6 +43,7 @@ def get_last_phase(context):
 
 @command('upgrade', help='Upgrades the current system to the next available major version.')
 @command_opt('resume', is_flag=True, help='Continue the last execution after it was stopped (e.g. after reboot)')
+@command_opt('reboot', is_flag=True, help='Automatically performs reboot when requested.')
 @command_opt('--whitelist-experimental', action='append', metavar='ActorName',
              help='Enables experimental actors')
 def upgrade(args):
@@ -66,7 +67,7 @@ def upgrade(args):
     except LeappError as exc:
         sys.stderr.write(exc.message)
         sys.exit(1)
-    workflow = repositories.lookup_workflow('IPUWorkflow')()
+    workflow = repositories.lookup_workflow('IPUWorkflow')(auto_reboot=args.reboot)
     for actor_name in args.whitelist_experimental or ():
         actor = repositories.lookup_actor(actor_name)
         if actor:

--- a/leapp/dialogs/__init__.py
+++ b/leapp/dialogs/__init__.py
@@ -19,3 +19,12 @@ class RawMessageDialog(Dialog):
 
     def __init__(self, message):
         super(RawMessageDialog, self).__init__(scope=None, reason=message)
+
+    def request_answers(self, store, renderer):
+        """
+        :param store: AnswerStore instance
+        :param renderer: Target renderer instance
+        :return: Dictionary with answers once retrieved
+        """
+        renderer.render(self)
+        return {}

--- a/leapp/dialogs/dialog.py
+++ b/leapp/dialogs/dialog.py
@@ -82,4 +82,4 @@ class Dialog(object):
             self._store = store
             renderer.render(self)
             self._store = None
-        return dict(store.get(self.scope))
+        return dict(store.get(self.scope, {}))

--- a/leapp/workflows/flags.py
+++ b/leapp/workflows/flags.py
@@ -1,5 +1,7 @@
 class Flags(object):
     restart_after_phase = False
+    request_restart_after_phase = False
 
-    def __init__(self, restart_after_phase=False):
+    def __init__(self, request_restart_after_phase=False, restart_after_phase=False):
+        self.request_restart_after_phase = request_restart_after_phase
         self.restart_after_phase = restart_after_phase


### PR DESCRIPTION
Previously reboots were always executed automatically, however this
behaviour isn't always wanted. Users and testers might need to do
things before the actual reboot.

This patch introduces a --reboot flag to the leapp upgrade
command line tool which will instruct the framework to perform
the reboot when it is requested. When the flag is not present
the upgrade will not performed and just a message will be presented
to the user asking them to reboot.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>