### PR TITLE
models: Support model references in fields.Model

### DIFF
--- a/leapp/models/fields/__init__.py
+++ b/leapp/models/fields/__init__.py
@@ -431,9 +431,10 @@ class Model(Field):
 
     def _validate_model_value(self, value, name):
         super(Model, self)._validate_model_value(value, name)
-        if value and value is not missing and not isinstance(value, self._model_type):
+        resolved_model = getattr(self._model_type, '_resolved', self._model_type)
+        if value and value is not missing and not isinstance(value, resolved_model):
             raise ModelViolationError('Expected an instance of {} for the {} attribute but got {}'.format(
-                self._model_type.__name__, name, type(value)))
+                resolved_model.__name__, name, type(value)))
 
     def _validate_builtin_value(self, value, name):
         super(Model, self)._validate_model_value(value, name)


### PR DESCRIPTION
Previously the Model field type, did not check whether or not it
received a reference as model to use, which resulted in some validation
error if the real model was passed to it. This PR fixes this problem
by trying to get the _resolved field from the model and defaults
to the actual model type that has been passed.

Fixes https://github.com/leapp-to/leapp/issues/374

Related-issue: https://github.com/leapp-to/leapp/issues/374
Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>